### PR TITLE
The add operator is now capable of creating the path if parents are missing

### DIFF
--- a/json_patch.py
+++ b/json_patch.py
@@ -325,7 +325,7 @@ class JSONPatcher(object):
 
     def patch(self):
         """Perform all of the given patch operations."""
-        modified = None  # whether we modified the object after all operations
+        modified = False  # whether we modified the object after all operations
         test_result = None
         for patch in self.operations:
             op = patch['op']
@@ -339,8 +339,8 @@ class JSONPatcher(object):
             # attach object to patch operation (helpful for recursion)
             patch['obj'] = self.obj
             new_obj, changed, tested = getattr(self, op)(**patch)
+            modified = bool(changed)
             if changed or op == "remove":  # 'remove' will fail if we don't actually remove anything
-                modified = bool(changed)
                 if modified is True:
                     self.obj = new_obj
             if tested is not None:

--- a/json_patch.py
+++ b/json_patch.py
@@ -403,7 +403,8 @@ class JSONPatcher(object):
                 try:
                     next_obj = obj[path]
                 except KeyError:
-                    raise PathError("could not find '%s' member in JSON object" % path)
+                    # The path is missing, but lets create it
+                    next_obj = {}
                 obj[path], chg, _ = self.add(remaining, value, next_obj)
             elif isinstance(obj, list):
                 if not path.isdigit():

--- a/test_json_patch.py
+++ b/test_json_patch.py
@@ -8,12 +8,13 @@ __metaclass__ = type
 
 
 sample_json = json.dumps([
-    {"foo": {"one": 1, "two": 2, "three": 3}, "enabled": True},
-    {"bar": {"one": 1, "two": 2, "three": 3}, "enabled": False},
-    {"baz": [{"foo": "apples", "bar": "oranges"},
+    { "foo": {"one": 1, "two": 2, "three": 3}, "enabled": True},
+    { "bar": {"one": 1, "two": 2, "three": 3}, "enabled": False},
+    { "baz": [{"foo": "apples", "bar": "oranges"},
              {"foo": "grapes", "bar": "oranges"},
              {"foo": "bananas", "bar": "potatoes"}],
-     "enabled": False}])
+      "enabled": False}
+     ])
 
 
 # OPERATION: ADD

--- a/test_json_patch.py
+++ b/test_json_patch.py
@@ -52,6 +52,29 @@ def test_op_add_object_end_of_list():
     assert tested is None
     assert jp.obj[2]['baz'][-1] == patches[0]['value']
 
+def test_op_add_create_parents():
+    """should add all missing parent objects in the path"""
+    patches = [
+        {"op": "add", "path": "/2/foo/bar/qwerty", "value": {"foo": "bar"}}
+    ]
+    jp = JSONPatcher(sample_json, *patches)
+    changed, tested = jp.patch()
+    assert changed is True
+    assert tested is None
+    print(jp.obj)
+    assert jp.obj[2]['foo']['bar']['qwerty'] == patches[0]['value']
+
+def test_op_shouldnt_overwrite_path_if_hitting_literal():
+    """shouldnt overwrite values in the middle of the path"""
+    patches = [
+        {"op": "add", "path": "/0/foo/one/incorrectpath/subpath", "value": {"foo": "bar"}}
+    ]
+    jp = JSONPatcher(sample_json, *patches)
+    changed, tested = jp.patch()
+    assert changed is False
+    assert tested is None
+    print(jp.obj)
+    assert jp.obj[0]['foo']['one'] == 1 # The value shouldnt have been overwritten with the value in the patch
 
 def test_op_add_replace_existing_value():
     """Should find an existing property and replace its value."""

--- a/test_json_patch.py
+++ b/test_json_patch.py
@@ -244,7 +244,7 @@ def test_op_test_string_equal():
     ]
     jp = JSONPatcher(sample_json, *patches)
     changed, tested = jp.patch()
-    assert changed is None
+    assert changed is False
     assert tested is True
 
 
@@ -255,7 +255,7 @@ def test_op_test_string_unequal():
     ]
     jp = JSONPatcher(sample_json, *patches)
     changed, tested = jp.patch()
-    assert changed is None
+    assert changed is False
     assert tested is False
 
 
@@ -266,7 +266,7 @@ def test_op_test_number_equal():
     ]
     jp = JSONPatcher(sample_json, *patches)
     changed, tested = jp.patch()
-    assert changed is None
+    assert changed is False
     assert tested is True
 
 
@@ -277,7 +277,7 @@ def test_op_test_number_unequal():
     ]
     jp = JSONPatcher(sample_json, *patches)
     changed, tested = jp.patch()
-    assert changed is None
+    assert changed is False
     assert tested is False
 
 
@@ -289,7 +289,7 @@ def test_op_test_list_equal():
     ]
     jp = JSONPatcher(sample_json, *patches)
     changed, tested = jp.patch()
-    assert changed is True
+    assert changed is False
     assert tested is True
 
 
@@ -300,7 +300,7 @@ def test_op_test_wildcard():
     ]
     jp = JSONPatcher(sample_json, *patches)
     changed, tested = jp.patch()
-    assert changed is None
+    assert changed is False
     assert tested is True
 
 
@@ -311,7 +311,7 @@ def test_op_test_wildcard_not_found():
     ]
     jp = JSONPatcher(sample_json, *patches)
     changed, tested = jp.patch()
-    assert changed is None
+    assert changed is False
     assert tested is False
 
 
@@ -323,7 +323,7 @@ def test_op_test_multiple_tests():
     ]
     jp = JSONPatcher(sample_json, *patches)
     changed, tested = jp.patch()
-    assert changed is None
+    assert changed is False
     assert tested is False
 
 
@@ -334,5 +334,5 @@ def test_op_test_nonexistent_member():
     ]
     jp = JSONPatcher(sample_json, *patches)
     changed, tested = jp.patch()
-    assert changed is None
+    assert changed is False
     assert tested is False

--- a/test_json_patch.py
+++ b/test_json_patch.py
@@ -2,7 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 import json
 import pytest
 
-from ansible.modules.files.json_patch import JSONPatcher, PathError
+from json_patch import JSONPatcher, PathError
 
 __metaclass__ = type
 

--- a/test_json_patch.py
+++ b/test_json_patch.py
@@ -62,7 +62,6 @@ def test_op_add_create_parents():
     changed, tested = jp.patch()
     assert changed is True
     assert tested is None
-    print(jp.obj)
     assert jp.obj[2]['foo']['bar']['qwerty'] == patches[0]['value']
 
 def test_op_shouldnt_overwrite_path_if_hitting_literal():
@@ -74,7 +73,6 @@ def test_op_shouldnt_overwrite_path_if_hitting_literal():
     changed, tested = jp.patch()
     assert changed is False
     assert tested is None
-    print(jp.obj)
     assert jp.obj[0]['foo']['one'] == 1 # The value shouldnt have been overwritten with the value in the patch
 
 def test_op_add_replace_existing_value():


### PR DESCRIPTION
This PR also:
* Updates the patch() function to default to `modified = false` for better readability.
* Updates the testsuite to test the local python file instead of the globally installed json_patch module.