### PR TITLE
fix: modified=None when patch had no effect, corrected to False

### DIFF
--- a/json_patch.py
+++ b/json_patch.py
@@ -345,6 +345,8 @@ class JSONPatcher(object):
                     self.obj = new_obj
             if tested is not None:
                 test_result = False if test_result is False else tested  # one false test fails everything
+        if op != "test" and modified is None:
+            modified = False
         return modified, test_result
 
     def _get(self, path, obj, **discard):


### PR DESCRIPTION
Currently the Python tests are failing for non-"test" ops whose value already matches the existing value in the JSON (therefore, the JSON was not changed). This is because the "modified" return value of JSONPatcher.patch() is set to None by default, and is never set to False if none of the patches made any changes to the existing JSON object.

For ops of type "test", there are existing Python tests which are expecting this return value to be None, which makes sense I guess, since "test" ops are never expected to change the JSON.

Therefore, this fix will set the "modified" return value to False if the op is not "test" and if it was not set to True by any of the executed patches.

This corrects failures for the following tests:

- test_op_add_ignore_existing_value
- test_op_move_unchanged_on_nonexistent

Now all tests pass :)