### PR TITLE
feat: create_parents for add operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The module `json_patch` takes the following options:
 | `src` | The path to a file containing JSON | |
 | `dest` | The path to an optional output file to write the patched JSON (default is to overwrite `src` file) | |
 | `operations` | A list of valid operations to perform against the given JSON file | See [RFC 6902](https://tools.ietf.org/html/rfc6902#section-4) |
+| `create_parents` | For add operations, create any parent objects/arrays in the JSON-Pointer which do not yet exist (against Section 4.1 of RFC6902) (default: `no`) | `yes`/`no` |
 | `backup` | Backup the JSON file (the one that will be overwritten) before editing (default: `no`) | `yes`/`no` |
 | `unsafe_writes` | Allow Ansible to fall back to unsafe (i.e. non-atomic) methods of writing files (default: `no`) | `yes`/`no` |
 | `pretty` | Write JSON output in human-readable format | `yes`/`no` |


### PR DESCRIPTION
Fixes: #25

Adds an option to the module which will create any parent objects/arrays needed to reach the child member in an "add" operation. If the next reference token in the path is either "0" or "-", an array will be created. If it is any other number, the parent will not be created and the operation will fail to avoid edge cases and quirks in idempotency. In all other cases, an object is created.

This is in direct contradiction to Section 4.1 of RFC6902, which is why this feature is OFF by default. However, it makes this module much more useful when editing JSON configs.

Please note that two tests are currently failing in the master branch, and are expected to fail here too. The fix for these is in #31, and the tests written in this PR do pass!